### PR TITLE
Fix deadlock in PostgresListener

### DIFF
--- a/src/LogExtensions.cs
+++ b/src/LogExtensions.cs
@@ -129,4 +129,11 @@ internal static partial class LogExtensions
         Message = "Postgres backplane configuration is invalid: {Message}"
     )]
     public static partial void BackplaneConfigurationInvalid(this ILogger logger, string message);
+
+    [LoggerMessage(
+        EventId = 180,
+        Level = LogLevel.Error,
+        Message = "Postgres backplane failed to resolve the payload for notification on channel {Channel}."
+    )]
+    public static partial void BackplaneFailedResolvingPayload(this ILogger logger, string channel, Exception exception);
 }

--- a/src/PayloadStrategy.cs
+++ b/src/PayloadStrategy.cs
@@ -141,13 +141,18 @@ public sealed class TablePayloadStrategy : IPayloadStrategy
             }
         }
 
+        var id = Convert.ToInt64(eventArgs.Payload[3..]);
+
         using var connection = _backplaneOptions.Value.DataSource.OpenConnection();
         using var command = new NpgsqlCommand(_readQuery, connection);
 
-        command.Parameters.Add(new("id", Convert.ToInt64(eventArgs.Payload[3..])));
+        command.Parameters.Add(new("id", id));
 
         using var reader = command.ExecuteReader();
-        reader.Read();
+        if (!reader.Read())
+        {
+            throw new InvalidOperationException($"Payload record {id} was not found in {_tableName}. It may have been removed by automatic cleanup before it could be read; consider increasing AutomaticCleanupTtlMs.");
+        }
 
         var message = (byte[])reader[0];
         return message;

--- a/src/PayloadTableOptions.cs
+++ b/src/PayloadTableOptions.cs
@@ -61,7 +61,7 @@ public class PayloadTableOptions
     /// The minimum TTL of a payload record in the table in milliseconds.
     /// Default: <c>300000</c> (5 minutes)
     /// </summary>
-    public int AutomaticCleanupTtlMs { get; set; } = 1000;
+    public int AutomaticCleanupTtlMs { get; set; } = 300000;
 
     /// <summary>
     /// The interval between cleanups in milliseconds.

--- a/src/PostgresHubLifetimeManager.cs
+++ b/src/PostgresHubLifetimeManager.cs
@@ -781,7 +781,18 @@ public sealed class PostgresHubLifetimeManager<THub> : HubLifetimeManager<THub>,
         _logger.BackplaneReadNotification(e.Channel);
         if (_notificationHandlers.TryGetValue(e.Channel, out var handler))
         {
-            handler(_payloadStrategy.ResolveNotificationPayload(e));
+            byte[] payload;
+            try
+            {
+                payload = _payloadStrategy.ResolveNotificationPayload(e);
+            }
+            catch (Exception ex)
+            {
+                _logger.BackplaneFailedResolvingPayload(e.Channel, ex);
+                return;
+            }
+
+            handler(payload);
         }
     }
 

--- a/src/PostgresListener.cs
+++ b/src/PostgresListener.cs
@@ -52,7 +52,8 @@ internal sealed class PostgresListener(NpgsqlDataSource dataSource) : IAsyncDisp
                         }
                         catch
                         {
-                            await ReconnectAsync(_cts.Token);
+                            await ReconnectCoreAsync(_cts.Token);
+                            connection = _connection!;
                         }
                     }
                 }
@@ -76,32 +77,37 @@ internal sealed class PostgresListener(NpgsqlDataSource dataSource) : IAsyncDisp
 
         try
         {
-            try
-            {
-                if (_connection is not null)
-                {
-                    await _connection.CloseAsync();
-                }
-            }
-            catch { }
-
-            _connection?.Dispose();
-
-            _connection = await dataSource.OpenConnectionAsync(ct);
-            
-            _connection.Notification += (_, e) => OnNotification?.Invoke(this, e);
-
-            if (_channels.Count > 0)
-            {
-                await ExecAsync(BuildListenSql(_channels), ct);
-            }
-
-            _waitCts.Cancel();
+            await ReconnectCoreAsync(ct);
         }
         finally
         {
             _gate.Release();
         }
+    }
+
+    private async Task ReconnectCoreAsync(CancellationToken ct)
+    {
+        try
+        {
+            if (_connection is not null)
+            {
+                await _connection.CloseAsync();
+            }
+        }
+        catch { }
+
+        _connection?.Dispose();
+
+        _connection = await dataSource.OpenConnectionAsync(ct);
+
+        _connection.Notification += (_, e) => OnNotification?.Invoke(this, e);
+
+        if (_channels.Count > 0)
+        {
+            await ExecAsync(BuildListenSql(_channels), ct);
+        }
+
+        _waitCts.Cancel();
     }
 
     private static string BuildListenSql(IEnumerable<string> channels)


### PR DESCRIPTION
When `WaitAsync` is cancelled, `PumpAsync` acquires the gait then drains operations. However, if one of the operations throws then it calls `ReconnectAsync` before releasing the gate. `ReconnectAsync` will attempt to acquire the gate, resulting in deadlock.