### PR TITLE
Update username casing in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     assignees:
-      - "ianwold"
+      - "IanWold"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     assignees:
-      - "ianwold"
+      - "IanWold"


### PR DESCRIPTION
Attempts to fix issues like https://github.com/IanWold/PostgreSignalR/pull/90#issuecomment-4881665750

Best I can tell casing is the only thing making that error message show; it correctly assigns me.