### PR TITLE
POC: Remove Retries from Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Going forward, there is no requirement that this codebase conforms to the archit
 Being an inherently network-related product, integration tests provide the greatest source of confidence in the functionality of the backplane. [The integration test project](https://github.com/IanWold/PostgreSignalR/tree/main/tests/PostgreSignalR.IntegrationTests) is set up well to be able to test various scenarios involving multiple servers and clients. These tests use [Testcontainers](https://dotnet.testcontainers.org/) to create a Postgres server with an individual Postgres database per test. They also have a [standalone SignalR server](https://github.com/IanWold/PostgreSignalR/tree/main/tests/PostgreSignalR.IntegrationTests.App) providing functionality to cover all of the SignalR use cases. The integration tests can create multiple, separate instances of this server on Docker, and for each server can create multiple, separate clients. This makes it easy to cover various scenarios:
 
 ```csharp
-[RetryFact]
+[Fact]
 public async Task Test()
 {
     await using var server1 = await CreateServerAsync();

--- a/README_NUGET.md
+++ b/README_NUGET.md
@@ -105,7 +105,7 @@ Going forward, there is no requirement that this codebase conforms to the archit
 Being an inherently network-related product, integration tests provide the greatest source of confidence in the functionality of the backplane. [The integration test project](https://github.com/IanWold/PostgreSignalR/tree/main/PostgreSignalR.IntegrationTests) is set up well to be able to test various scenarios involving multiple servers and clients. These tests use [Testcontainers](https://dotnet.testcontainers.org/) to create a Postgres server with an individual Postgres database per test. They also have a [standalone SignalR server](https://github.com/IanWold/PostgreSignalR/tree/main/PostgreSignalR.IntegrationTests.App) providing functionality to cover all of the SignalR use cases. The integration tests can create multiple, separate instances of this server on Docker, and for each server can create multiple, separate clients. This makes it easy to cover various scenarios:
 
 ```csharp
-[RetryFact]
+[Fact]
 public async Task Test()
 {
     await using var server1 = await CreateServerAsync();

--- a/tests/PostgreSignalR.IntegrationTests/Global.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Global.cs
@@ -1,2 +1,1 @@
-global using xRetry.v3;
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/PostgreSignalR.IntegrationTests/PostgreSignalR.IntegrationTests.csproj
+++ b/tests/PostgreSignalR.IntegrationTests/PostgreSignalR.IntegrationTests.csproj
@@ -18,7 +18,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xRetry.v3" Version="1.0.0-rc3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PostgreSignalR.IntegrationTests/Tests/BroadcastTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/BroadcastTests.cs
@@ -4,7 +4,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class BroadcastTests(ContainerFixture fixture) : BaseTest(fixture)
 {
-    [RetryFact]
+    [Fact]
     public async Task CallerOnly_DoesNotReachOthers()
     {
         await using var caller = await Server1.CreateClientAsync();
@@ -18,7 +18,7 @@ public class BroadcastTests(ContainerFixture fixture) : BaseTest(fixture)
         await other.EnsureNoMessageAsync(nameof(IClient.Message));
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Others_ReachAllOtherClients()
     {
         await using var caller = await Server1.CreateClientAsync();
@@ -36,7 +36,7 @@ public class BroadcastTests(ContainerFixture fixture) : BaseTest(fixture)
         await caller.EnsureNoMessageAsync(nameof(IClient.Message));
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Broadcast_AllExceptOneDoesNotReachExcluded()
     {
         await using var client1 = await Server1.CreateClientAsync();

--- a/tests/PostgreSignalR.IntegrationTests/Tests/ClientReturnTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/ClientReturnTests.cs
@@ -2,7 +2,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class ClientReturnTests(ContainerFixture fixture) : BaseTest(fixture)
 {
-    [RetryFact]
+    [Fact]
     public async Task Invoke_ReturnsAcrossServers()
     {
         await using var caller = await Server1.CreateClientAsync();
@@ -15,7 +15,7 @@ public class ClientReturnTests(ContainerFixture fixture) : BaseTest(fixture)
         Assert.Equal($"echo:{ShortMessage}", result);
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Invoke_ReturnsWithinSameServer()
     {
         await using var caller = await Server1.CreateClientAsync();

--- a/tests/PostgreSignalR.IntegrationTests/Tests/ConnectionTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/ConnectionTests.cs
@@ -4,7 +4,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class ConnectionTests(ContainerFixture fixture) : BaseTest(fixture)
 {
-    [RetryFact]
+    [Fact]
     public async Task Connection_TargetsSingleConnection_SameServer()
     {
         await using var sender = await Server1.CreateClientAsync();
@@ -22,7 +22,7 @@ public class ConnectionTests(ContainerFixture fixture) : BaseTest(fixture)
         await bystander.EnsureNoMessageAsync(nameof(IClient.Message));
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Connections_TargetsMultiple()
     {
         await using var sender = await Server1.CreateClientAsync();

--- a/tests/PostgreSignalR.IntegrationTests/Tests/CustomPrefixTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/CustomPrefixTests.cs
@@ -4,7 +4,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class CustomPrefixTests(ContainerFixture fixture) : ConfigurableBaseTest(fixture, new(Prefix: "custom"))
 {
-    [RetryFact]
+    [Fact]
     public async Task Broadcast_AllServersReceive()
     {
         await using var client1 = await Server1.CreateClientAsync();
@@ -19,7 +19,7 @@ public class CustomPrefixTests(ContainerFixture fixture) : ConfigurableBaseTest(
         Assert.Equal(ShortMessage, (await messageFromClient2).Arg<string>());
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Group_SendHitsMembersAcrossServers()
     {
         await using var member1 = await Server1.CreateClientAsync();

--- a/tests/PostgreSignalR.IntegrationTests/Tests/EventPayloadStrategyOnlyTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/EventPayloadStrategyOnlyTests.cs
@@ -4,7 +4,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class EventPayloadStrategyOnlyTests(ContainerFixture fixture) : ConfigurableBaseTest(fixture, new(UseTableStrategy: false))
 {
-    [RetryFact]
+    [Fact]
     public async Task Broadcast_AllServersReceive()
     {
         await using var client1 = await Server1.CreateClientAsync();
@@ -19,7 +19,7 @@ public class EventPayloadStrategyOnlyTests(ContainerFixture fixture) : Configura
         Assert.Equal(ShortMessage, (await messageFromClient2).Arg<string>());
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Group_SendHitsMembersAcrossServers()
     {
         await using var member1 = await Server1.CreateClientAsync();

--- a/tests/PostgreSignalR.IntegrationTests/Tests/GroupTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/GroupTests.cs
@@ -4,7 +4,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class GroupTests(ContainerFixture fixture) : BaseTest(fixture)
 {
-    [RetryFact]
+    [Fact]
     public async Task Group_RemovalStopsDelivery()
     {
         await using var member1 = await Server1.CreateClientAsync();
@@ -23,7 +23,7 @@ public class GroupTests(ContainerFixture fixture) : BaseTest(fixture)
         await member2.EnsureNoMessageAsync(nameof(IClient.Message));
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Groups_SendToAllInGroupsHitsMembersOfEachGroup()
     {
         await using var sender = await Server1.CreateClientAsync();
@@ -51,7 +51,7 @@ public class GroupTests(ContainerFixture fixture) : BaseTest(fixture)
         await outsider.EnsureNoMessageAsync(nameof(IClient.Message));
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Groups_OthersInGroupExcludesCaller()
     {
         await using var caller = await Server1.CreateClientAsync();
@@ -71,7 +71,7 @@ public class GroupTests(ContainerFixture fixture) : BaseTest(fixture)
         await outsider.EnsureNoMessageAsync(nameof(IClient.Message));
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Groups_GroupExceptExcludesSpecifiedConnection()
     {
         await using var sender = await Server1.CreateClientAsync();

--- a/tests/PostgreSignalR.IntegrationTests/Tests/HashAlwaysChannelNamingTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/HashAlwaysChannelNamingTests.cs
@@ -4,7 +4,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class HashAlwaysChannelNamingTests(ContainerFixture fixture) : ConfigurableBaseTest(fixture, new(ChannelNameNormaization: ChannelNameNormaization.HashAlways))
 {
-    [RetryFact]
+    [Fact]
     public async Task Broadcast_AllServersReceive()
     {
         await using var client1 = await Server1.CreateClientAsync();
@@ -19,7 +19,7 @@ public class HashAlwaysChannelNamingTests(ContainerFixture fixture) : Configurab
         Assert.Equal(ShortMessage, (await messageFromClient2).Arg<string>());
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Group_SendHitsMembersAcrossServers()
     {
         await using var member1 = await Server1.CreateClientAsync();

--- a/tests/PostgreSignalR.IntegrationTests/Tests/LargePayloadTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/LargePayloadTests.cs
@@ -4,7 +4,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class LargePayloadTests(ContainerFixture fixture) : BaseTest(fixture)
 {
-    [RetryFact]
+    [Fact]
     public async Task LargePayload_AllServersReceive()
     {
         await using var client1 = await Server1.CreateClientAsync();

--- a/tests/PostgreSignalR.IntegrationTests/Tests/ListenerConnectionTerminationTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/ListenerConnectionTerminationTests.cs
@@ -4,7 +4,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class ListenerConnectionTerminationTests(ContainerFixture fixture) : ResiliencyTestBase(fixture, new(Prefix: "backend-kill"))
 {
-    [RetryFact]
+    [Fact]
     public async Task BackplaneRecoversAfterListenerConnectionIsTerminated()
     {
         await using var client1 = await Server1.CreateClientAsync();
@@ -22,7 +22,7 @@ public class ListenerConnectionTerminationTests(ContainerFixture fixture) : Resi
         await AssertEventuallyDeliveredAsync(client1, client2);
     }
 
-    [RetryFact]
+    [Fact]
     public async Task BackplaneRecoversFromRepeatedDisruptions()
     {
         await using var client1 = await Server1.CreateClientAsync();
@@ -37,7 +37,7 @@ public class ListenerConnectionTerminationTests(ContainerFixture fixture) : Resi
         }
     }
 
-    [RetryFact]
+    [Fact]
     public async Task GroupSubscriptionSurvivesReconnect()
     {
         await using var member = await Server1.CreateClientAsync();
@@ -53,7 +53,7 @@ public class ListenerConnectionTerminationTests(ContainerFixture fixture) : Resi
         await AssertEventuallyDeliveredAsync(() => sender.Send.SendToAllInGroup(GroupName, Guid.NewGuid().ToString()), member, nameof(IClient.Message));
     }
 
-    [RetryFact]
+    [Fact]
     public async Task InvokeRecoversAfterReconnect()
     {
         await using var caller = await Server1.CreateClientAsync();
@@ -77,7 +77,7 @@ public class ListenerConnectionTerminationTests(ContainerFixture fixture) : Resi
         Assert.Equal($"echo:{ShortMessage}", result);
     }
 
-    [RetryFact]
+    [Fact]
     public async Task NewConnectionEstablishedDuringDisruptionEventuallyWorks()
     {
         await using var existingClient = await Server1.CreateClientAsync();

--- a/tests/PostgreSignalR.IntegrationTests/Tests/PayloadTableAlwaysStorageTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/PayloadTableAlwaysStorageTests.cs
@@ -4,7 +4,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class PayloadTableAlwaysStorageTests(ContainerFixture fixture) : ConfigurableBaseTest(fixture, new(PayloadTableStorage: PayloadTableStorage.Always))
 {
-    [RetryFact]
+    [Fact]
     public async Task Broadcast_ShortMessageStillDelivered()
     {
         await using var client1 = await Server1.CreateClientAsync();
@@ -19,7 +19,7 @@ public class PayloadTableAlwaysStorageTests(ContainerFixture fixture) : Configur
         Assert.Equal(ShortMessage, (await messageFromClient2).Arg<string>());
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Connection_TargetsSingleConnection()
     {
         await using var sender = await Server1.CreateClientAsync();

--- a/tests/PostgreSignalR.IntegrationTests/Tests/PayloadTableCleanupDisabledTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/PayloadTableCleanupDisabledTests.cs
@@ -2,12 +2,12 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class PayloadTableCleanupDisabledTests(ContainerFixture fixture) : PayloadTableTestBase(fixture, new(PayloadTableStorage: PayloadTableStorage.Always, AutomaticCleanup: false))
 {
-    [RetryFact]
+    [Fact]
     public async Task ExpiredPayloadRowSurvivesWhenCleanupDisabled()
     {
         var id = await InsertPayloadRowAsync(TimeSpan.FromHours(1));
 
-        await Task.Delay(TimeSpan.FromSeconds(2));
+        await Task.Delay(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
 
         await AssertRowStillExistsAsync(id);
     }

--- a/tests/PostgreSignalR.IntegrationTests/Tests/PayloadTableCleanupTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/PayloadTableCleanupTests.cs
@@ -2,19 +2,19 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class PayloadTableCleanupTests(ContainerFixture fixture) : PayloadTableTestBase(fixture, new(PayloadTableStorage: PayloadTableStorage.Always, AutomaticCleanupIntervalMs: 500))
 {
-    [RetryFact]
+    [Fact]
     public async Task ExpiredPayloadRowIsRemovedByAutomaticCleanup()
     {
         var id = await InsertPayloadRowAsync(TimeSpan.FromHours(1));
         await AssertRowRemovedWithinAsync(id);
     }
 
-    [RetryFact]
+    [Fact]
     public async Task NonExpiredPayloadRowSurvivesAutomaticCleanup()
     {
         var id = await InsertPayloadRowAsync(TimeSpan.Zero);
 
-        await Task.Delay(TimeSpan.FromSeconds(2));
+        await Task.Delay(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
 
         await AssertRowStillExistsAsync(id);
     }

--- a/tests/PostgreSignalR.IntegrationTests/Tests/PayloadTableCustomTtlTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/PayloadTableCustomTtlTests.cs
@@ -2,7 +2,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class PayloadTableCustomTtlTests(ContainerFixture fixture) : PayloadTableTestBase(fixture, new(PayloadTableStorage: PayloadTableStorage.Always, AutomaticCleanupTtlMs: 500, AutomaticCleanupIntervalMs: 250))
 {
-    [RetryFact]
+    [Fact]
     public async Task CustomTtlIsHonoredByAutomaticCleanup()
     {
         var id = await InsertPayloadRowAsync(TimeSpan.FromSeconds(2));

--- a/tests/PostgreSignalR.IntegrationTests/Tests/PostgresContainerRestartTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/PostgresContainerRestartTests.cs
@@ -4,7 +4,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class PostgresContainerRestartTests(PostgresRestartFixture fixture) : PostgresRestartTestBase(fixture)
 {
-    [RetryFact]
+    [Fact]
     public async Task BackplaneRecoversAfterPostgresRestart()
     {
         await using var client1 = await Server1.CreateClientAsync();
@@ -20,7 +20,7 @@ public class PostgresContainerRestartTests(PostgresRestartFixture fixture) : Pos
         await RetryAssertions.AssertEventuallyDeliveredAsync(client1, client2);
     }
 
-    [RetryFact]
+    [Fact]
     public async Task BackplaneRecoversWhenFirstConnectionOccursDuringOutage()
     {
         await StopPostgresAsync();

--- a/tests/PostgreSignalR.IntegrationTests/Tests/ServerRestartTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/ServerRestartTests.cs
@@ -4,7 +4,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class ServerRestartTests(ContainerFixture fixture) : ConfigurableBaseTest(fixture, new(Prefix: "restart"))
 {
-    [RetryFact]
+    [Fact]
     public async Task ServerRecoversAfterRestart()
     {
         await using var client1 = await Server1.CreateClientAsync();

--- a/tests/PostgreSignalR.IntegrationTests/Tests/UserTests.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Tests/UserTests.cs
@@ -4,7 +4,7 @@ namespace PostgreSignalR.IntegrationTests;
 
 public class UserTests(ContainerFixture fixture) : BaseTest(fixture)
 {
-    [RetryFact]
+    [Fact]
     public async Task Users_SendToUserHitsAllConnections()
     {
         await using var user1a = await Server1.CreateClientAsync("u1");

--- a/tests/PostgreSignalR.IntegrationTests/Utilities/PayloadTestBase.cs
+++ b/tests/PostgreSignalR.IntegrationTests/Utilities/PayloadTestBase.cs
@@ -10,7 +10,7 @@ public abstract class PayloadTestBase<TPayload>(ContainerFixture fixture) : Base
     protected abstract Task SendToGroupAsync(TestClient sender, string groupName, TPayload payload);
     protected abstract Task SendToUsersAsync(TestClient sender, string[] userIds, TPayload payload);
 
-    [RetryFact]
+    [Fact]
     public async Task Broadcast_AllServersReceive()
     {
         await using var client1 = await Server1.CreateClientAsync();
@@ -25,7 +25,7 @@ public abstract class PayloadTestBase<TPayload>(ContainerFixture fixture) : Base
         Assert.Equal(Payload, (await messageFromClient2).Arg<TPayload>());
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Connection_TargetsSingleConnection()
     {
         await using var sender = await Server1.CreateClientAsync();
@@ -43,7 +43,7 @@ public abstract class PayloadTestBase<TPayload>(ContainerFixture fixture) : Base
         await bystander.EnsureNoMessageAsync(MessageKey);
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Group_SendHitsMembersAcrossServers()
     {
         await using var member1 = await Server1.CreateClientAsync();
@@ -64,7 +64,7 @@ public abstract class PayloadTestBase<TPayload>(ContainerFixture fixture) : Base
         await outsider.EnsureNoMessageAsync(MessageKey);
     }
 
-    [RetryFact]
+    [Fact]
     public async Task Users_SendToUsersHitsMultipleUsers()
     {
         await using var user1 = await Server1.CreateClientAsync("u1");


### PR DESCRIPTION
Trying to see if new, more resilient tests don't need to be reran